### PR TITLE
LUT3D Category to extract CIColorCube data from a LUT3D Object

### DIFF
--- a/Classes/LUT+CubeData.h
+++ b/Classes/LUT+CubeData.h
@@ -1,0 +1,40 @@
+//
+//  LUT+CubeData.h
+//
+//
+//  Created by Bruce Johnson on 1/15/15.
+//
+//
+
+#import "LUT3D.h"
+
+
+/**
+ Category to allow a single CIFilter instantace to use multiple LUT3Ds
+ 
+	 //CIColorCube filter set up in a controller class:
+	 CIFilter *_colorCubeFilter = [CIFilter filterWithName:@"CIColorCube"];
+
+	 //multiple LUT3D's set up
+	 LUT3D *lutOne = [LUT3D LUTFromURL: pathURL1];
+	 LUT3D *lutTwo = [LUT3D LUTFromURL: pathURL2];
+
+	 NSData *cubeData = nil;
+	 size_t size;
+
+	if (useLut1) {
+		size = [self.lutOne LUTCubeData: &cubeData];
+	} else {
+		size = [self.lutTwo LUTCubeData: &cubeData];
+	}
+
+	[_colorCubeFilter setValue: @(size) forKey: @"inputCubeDimension"];
+	[_colorCubeFilter setValue: cubeData forKey: @"inputCubeData"];
+ 
+ **/
+
+@interface LUT3D (CubeData)
+
+- (size_t) LUTCubeData: (NSData **)data;
+
+@end

--- a/Classes/LUT+CubeData.m
+++ b/Classes/LUT+CubeData.m
@@ -1,0 +1,41 @@
+//
+//  LUT+CubeData.m
+//
+//
+//  Created by Bruce Johnson on 1/15/15.
+//
+//
+
+#import "LUT+CubeData.h"
+#import "LUT.h"
+#import <CocoaLUT/CocoaLUT.h>
+
+@implementation LUT3D (CubeData)
+
+- (size_t) LUTCubeData: (NSData **)returnData
+{
+	
+	NSUInteger sizeOfColorCubeFilter = clamp([self size], 0, COCOALUT_MAX_CICOLORCUBE_SIZE);
+	LUT3D *used3DLUT = [LUTAsLUT3D(self, sizeOfColorCubeFilter) LUTByChangingInputLowerBound:0.0 inputUpperBound:1.0];
+	
+	size_t size = [used3DLUT size];
+	size_t cubeDataSize = size * size * size * sizeof (float) * 4;
+	float *cubeData = (float *) malloc (cubeDataSize);
+	
+	[used3DLUT LUTLoopWithBlock:^(size_t r, size_t g, size_t b) {
+		LUTColor *transformedColor = [used3DLUT colorAtR:r g:g b:b];
+		
+		size_t offset = 4*(b*size*size + g*size + r);
+		
+		cubeData[offset]   = (float)transformedColor.red;
+		cubeData[offset+1] = (float)transformedColor.green;
+		cubeData[offset+2] = (float)transformedColor.blue;
+		cubeData[offset+3] = 1.0f;
+	}];
+	
+	*returnData = [NSData dataWithBytesNoCopy:cubeData length:cubeDataSize freeWhenDone:YES];
+
+	return size;
+}
+
+@end


### PR DESCRIPTION
for use when you can only have a single instance of a CIColorCube filter and you need to swap out the 3D lut data for that single filter.